### PR TITLE
Fix fourierCoeff FFT length bug

### DIFF
--- a/fourierCoeff.m
+++ b/fourierCoeff.m
@@ -3,7 +3,7 @@ function [A,B] = fourierCoeff(x)
 % coefficents of the fourier series representation of signal x
 
 L = length(x);
-fft_x = fft(x,L-1);
+fft_x = fft(x,L);
 
 % Normalized fft
 nfft_x = fft_x/L;


### PR DESCRIPTION
## Summary
- compute Fourier coefficients using the full input vector length
- normalize by the same FFT length to keep scaling consistent

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68485c3042d48331930906bddfe587c5